### PR TITLE
Boardand collision

### DIFF
--- a/GPA675_LAB2/Board.cpp
+++ b/GPA675_LAB2/Board.cpp
@@ -57,3 +57,17 @@ CellType Board::value(int column, int row) const
 {
     return mBoard[row * mWidth + (column)];
 }
+
+CellType Board::setValue(int column, int row, CellType ptr)
+{
+    // Retourne le contenu de la case visee (nullptr si vide, l'entite presente sinon)
+    CellType entity = value(column, row);
+    mBoard[row * mWidth + column] = ptr;
+    return entity;
+
+}
+
+void Board::reset(int column, int row)
+{
+    mBoard[row * mWidth + column] = nullptr;
+}

--- a/GPA675_LAB2/Board.h
+++ b/GPA675_LAB2/Board.h
@@ -25,17 +25,18 @@ public:
 	size_t getWidth() const;
 	size_t getHeight() const;
 	size_t getSize() const;
-	//Entity* value(size_t row, size_t column) const;						//accesseur retournant la valeur de la cellule sur la grille
 
 	CellType value(int column, int row) const;
 
 	//Mutateurs
-
+	CellType setValue(int column, int row, CellType ptr);
+	void reset(int column, int row);
 	//Fonction de Resize??
 
 	//buffer
 	//Entity* const& data() const;												// Accesseur en lecture seule sur le "buffer" de la grille.
 	//Entity* data();															// Accesseur en lecture/?criture sur le "buffer" de la grille.
+	
 
 private:
 

--- a/GPA675_LAB2/Entity.cpp
+++ b/GPA675_LAB2/Entity.cpp
@@ -4,6 +4,7 @@ Entity::Entity(Board& board)
 	: mBoard{ board }
 	, mAge{}
 	, mAlive{ true }
+	, mColliding{nullptr}
 {
 }
 

--- a/GPA675_LAB2/Entity.h
+++ b/GPA675_LAB2/Entity.h
@@ -28,5 +28,6 @@ protected:
 	Board& mBoard;
 	bool mAlive;
 	double mAge;
+	Entity* mColliding;
 };
 #endif

--- a/GPA675_LAB2/Pellet.cpp
+++ b/GPA675_LAB2/Pellet.cpp
@@ -4,6 +4,7 @@ Pellet::Pellet(Board& board)
     :StaticEntity(board)
     ,mScore{0}
 {
+    
 }
 
 Pellet::~Pellet()

--- a/GPA675_LAB2/Snake.cpp
+++ b/GPA675_LAB2/Snake.cpp
@@ -1,4 +1,5 @@
 #include "Snake.h"
+#include "Pellet.h"
 
 Snake::Snake(Board& board)
     :DynamicEntity(board)
@@ -66,7 +67,15 @@ void Snake::ticPrepare(real elapsedTime)
     }
    
     if (mTicTime > 1 / mSpeed) {
-        ticExecute();
+
+        grow(1);
+        if (dynamic_cast<Pellet*>(mColliding)) {
+            mColliding = nullptr;
+        }
+        else {
+            removeLast();
+        }
+
         mTicTime = 0;
     }
          
@@ -77,7 +86,7 @@ void Snake::ticPrepare(real elapsedTime)
 
 
 
-
+    
 
 
 
@@ -108,9 +117,8 @@ void Snake::ticPrepare(real elapsedTime)
 void Snake::ticExecute()
 {
     //1) Mettre a jour la position de la tete du serpent et ajouter les nouveaux segments
-
-    grow(1);
-    removeLast();
+    
+    
 
     //2) collision avec fruit->augmentation de la taille du serpent et point
 
@@ -381,7 +389,7 @@ void Snake::goToward(Direction direction)
 
 void Snake::grow(size_t size)
 {
-    //mSizeToGrow += size; 
+
     for (size_t i{}; i < size; ++i) {
         QPoint curPos = headPosition();
         QPoint newPos = curPos;
@@ -399,6 +407,7 @@ void Snake::grow(size_t size)
         }
         addFirst(newPos);
     }
+    mSizeToGrow = 0;
 }
 
 void Snake::shrink(size_t size)

--- a/GPA675_LAB2/Snake.cpp
+++ b/GPA675_LAB2/Snake.cpp
@@ -315,7 +315,7 @@ void Snake::removeLast()
 {
     QPoint pos = *mBody.last();
     mBody.removeLast();
-    mBoard.setValue(pos.x(), pos.y(), nullptr);
+    mBoard.reset(pos.x(), pos.y());
 }
 
 void Snake::setColors(QColor head, QColor body)

--- a/GPA675_LAB2/Snake.cpp
+++ b/GPA675_LAB2/Snake.cpp
@@ -7,7 +7,7 @@ Snake::Snake(Board& board)
     , mScore{ 0 }
     , mBody{Body(QPoint(32,32))}
     , mHeadDirection{ Direction::toUp }
-    , mSpeed{}
+    , mSpeed{1}
     , mSizeToGrow{ 0 }
     , mHeadColor{ QColor(0, 255, 0) }
     , mBodyColor{ QColor(0, 122, 0) }
@@ -16,6 +16,7 @@ Snake::Snake(Board& board)
     , LUTTurnRightDirection{}
     , LUTOppositeDirection{}
     , LUTDirectionAction{}
+    , mTicTime{0.0}
 {
     grow(1);
 }
@@ -42,17 +43,17 @@ bool Snake::isValid()
 
 bool Snake::isAlive()
 {
-    //v?rifier si le serpent s'est frapp? lui m?me
-    if (mBody.size() > 4) {
+    ////v?rifier si le serpent s'est frapp? lui m?me
+    //if (mBody.size() > 4) {
 
-        if (mBody.isColliding(headPosition())) {
+    //    if (mBody.isColliding(headPosition())) {
 
-            return false;
-        }
-    }
+    //        return false;
+    //    }
+    //}
 
-    //v?rifier si le serpent ? frapp? un mur    
-    //a confirmer si on a des bordures
+    ////v?rifier si le serpent ? frapp? un mur    
+    ////a confirmer si on a des bordures
 
 
     return true;
@@ -60,7 +61,15 @@ bool Snake::isAlive()
 
 void Snake::ticPrepare(real elapsedTime)
 {
-
+    if (elapsedTime > 0) {
+        mTicTime += elapsedTime;
+    }
+   
+    if (mTicTime > 1 / mSpeed) {
+        ticExecute();
+        mTicTime = 0;
+    }
+         
     //1) calculer la nouvelle position de la tete du serpent dependament de la direction
 
     QPoint newPos{ headPosition() };
@@ -98,11 +107,10 @@ void Snake::ticPrepare(real elapsedTime)
 
 void Snake::ticExecute()
 {
-    grow(1);
-    mBody.removeLast();
     //1) Mettre a jour la position de la tete du serpent et ajouter les nouveaux segments
 
-
+    grow(1);
+    removeLast();
 
     //2) collision avec fruit->augmentation de la taille du serpent et point
 
@@ -170,7 +178,7 @@ void Snake::draw(QPainter& painter)
 
 bool Snake::isColliding(QPoint const& position)
 {
-    return mBody.isColliding(position); //voir avec william pour l'implementation
+    return mColliding; //voir avec william pour l'implementation
 }
 
 QString Snake::name()
@@ -232,7 +240,7 @@ void Snake::reset(QPoint headPosition, Direction headDirection, size_t bodyLengt
 {
     //R?initialise la t?te du serpent
     mBody.clear();                      //on s'assure que le corps est vide
-    mBody.addFirst(headPosition);       //cr?er la t?te ? la position donn?e
+    addFirst(headPosition);       //cr?er la t?te ? la position donn?e
     mHeadDirection = headDirection;     //r?initialise la direction
 
     //on calcule chaque position ? rajouter au serpent individuellement
@@ -258,7 +266,7 @@ void Snake::reset(QPoint headPosition, Direction headDirection, size_t bodyLengt
             pos.setX(pos.x() + 1);
             break;
         }
-        mBody.addLast(pos);         //apr?s le calcul, nous rajoutons la partie du serpent
+        addLast(pos);         //apr?s le calcul, nous rajoutons la partie du serpent
     }
 
     mSpeed = initialSpeed;          //r?initialise la vitesse
@@ -281,14 +289,33 @@ void Snake::decreaseSpeed(SpeedType amout)
     mSpeed -= amout;
 }
 
+void Snake::addFirst(QPoint pos)
+{
+    mBody.addFirst(pos);
+    mColliding = mBoard.setValue(pos.x(), pos.y(), this);
+}
+
 void Snake::decelerate(SpeedType percentLess)
 {
     mSpeed *= 1 - percentLess; //percentless doit etre deja en pourcentage
 }
 
+void Snake::addLast(QPoint pos)
+{
+    mBody.addLast(pos);
+    mBoard.setValue(pos.x(), pos.y(), this);
+}
+
 void Snake::accelerate(SpeedType percentMore)
 {
     mSpeed = mSpeed * (percentMore + 1);
+}
+
+void Snake::removeLast()
+{
+    QPoint pos = *mBody.last();
+    mBody.removeLast();
+    mBoard.setValue(pos.x(), pos.y(), nullptr);
 }
 
 void Snake::setColors(QColor head, QColor body)
@@ -370,7 +397,7 @@ void Snake::grow(size_t size)
         else if (headDirection() == Direction::toLeft) {
             newPos.setX(curPos.x() - 1);
         }
-        mBody.addFirst(newPos);
+        addFirst(newPos);
     }
 }
 

--- a/GPA675_LAB2/Snake.h
+++ b/GPA675_LAB2/Snake.h
@@ -33,6 +33,7 @@ private:
 	QColor mHeadColor;
 	QColor mBodyColor;
 	bool mReverseProhibited;
+	qreal mTicTime;
 
 	const std::array<Direction, 4> LUTTurnLeftDirection{ Direction::toLeft,Direction::toUp, Direction::toRight,Direction::toDown };
 	const std::array<Direction, 4> LUTTurnRightDirection{ Direction::toRight,Direction::toDown, Direction::toLeft,Direction::toUp };
@@ -81,4 +82,7 @@ public:
 	void decreaseSpeed(SpeedType amout);						//fait
 	void decelerate(SpeedType percentLess);						//fait
 	void accelerate(SpeedType percentMore);						//fait
+	void addFirst(QPoint pos);
+	void addLast(QPoint pos);
+	void removeLast();
 };

--- a/GPA675_LAB2/SnakeGameApplication.cpp
+++ b/GPA675_LAB2/SnakeGameApplication.cpp
@@ -22,8 +22,11 @@ SnakeGameApplication::SnakeGameApplication()
     connect(&mTimer, &QTimer::timeout, this, &SnakeGameApplication::tic);
     mTimer.start();
     
-
+    Pellet* a = new Pellet(mBoard);
+    a->setPosition(QPoint(32, 20));
     mSnakeGameEngine.addEntity(new Snake(mBoard));
+    mSnakeGameEngine.addEntity(a);
+
     
 }
 

--- a/GPA675_LAB2/SnakeGameApplication.cpp
+++ b/GPA675_LAB2/SnakeGameApplication.cpp
@@ -6,14 +6,13 @@
 #include "Snake.h"
 
 
-
 SnakeGameApplication::SnakeGameApplication()
     : QWidget(nullptr)
     , mWindowSize(1024, 1024)
     , mTimer()
     , mElapsedTimer()
     , mSnakeGameEngine(mWindowSize)
- 
+    , mBoard{ Board(64, 64) }
 {
     setWindowTitle("Snake Equipe D");
     setFixedSize(mWindowSize);
@@ -22,13 +21,12 @@ SnakeGameApplication::SnakeGameApplication()
     connect(&mTimer, &QTimer::timeout, this, &SnakeGameApplication::tic);
     mTimer.start();
 
-    mSnakeGameEngine.startGameEngine();
-    
     Pellet* a = new Pellet(mBoard);
     a->setPosition(QPoint(32, 20));
-    mSnakeGameEngine.addEntity(new Snake(mBoard));
+    mSnakeGameEngine.addEntity(new Snake(mBoard));  //rajoute le serpent au board
     mSnakeGameEngine.addEntity(a);
     
+    mSnakeGameEngine.startGameEngine();
 }
 
 void SnakeGameApplication::keyPressEvent(QKeyEvent* event)

--- a/GPA675_LAB2/SnakeGameApplication.cpp
+++ b/GPA675_LAB2/SnakeGameApplication.cpp
@@ -22,13 +22,12 @@ SnakeGameApplication::SnakeGameApplication()
     connect(&mTimer, &QTimer::timeout, this, &SnakeGameApplication::tic);
     mTimer.start();
 
-
-
-
     mSnakeGameEngine.startGameEngine();
-
-
     
+    Pellet* a = new Pellet(mBoard);
+    a->setPosition(QPoint(32, 20));
+    mSnakeGameEngine.addEntity(new Snake(mBoard));
+    mSnakeGameEngine.addEntity(a);
     
 }
 

--- a/GPA675_LAB2/SnakeGameApplication.h
+++ b/GPA675_LAB2/SnakeGameApplication.h
@@ -32,6 +32,6 @@ private:
 	PressedKeys mPressedKeys;
 	//Composition
 	SnakeGameEngine mSnakeGameEngine;
-	
+	Board mBoard;
 };
 #endif //SNAKE_GAME_APPLICATIONn_H

--- a/GPA675_LAB2/SnakeGameEngine.cpp
+++ b/GPA675_LAB2/SnakeGameEngine.cpp
@@ -20,12 +20,24 @@ void SnakeGameEngine::tic(qreal elapsedTime)
 {
     mTotalElapsedTime += elapsedTime;
     for (auto i = mEntities.begin(); i != mEntities.end(); ++i) {
+
+        (*i)->ticPrepare(elapsedTime);
+
         Snake* snake{ dynamic_cast<Snake*>(*i) };
-        if (snake) {  
+        if (snake) {
             snake->ticExecute();
         }
-      
+    }
 
+
+    for (auto i = mEntities.begin(); i != mEntities.end();) {
+        if (!(*i)->isAlive()) {
+            delete* i;
+            i = mEntities.erase(i);
+        }
+        else {
+            ++i;
+        }
     }
 }
 void SnakeGameEngine::addEntity(Entity* entity)
@@ -73,6 +85,7 @@ void SnakeGameEngine::clearAllEntity()
         // Pour acc?der aux donn?es de l'objet Entity, on doit d?r?f?rencer le pointeur
         // puis appeler la m?thode ou acc?der aux membres
         (*i)->setDead();
+        
     }
 
 }

--- a/GPA675_LAB2/SnakeGameEngine.cpp
+++ b/GPA675_LAB2/SnakeGameEngine.cpp
@@ -18,12 +18,19 @@ SnakeGameEngine::~SnakeGameEngine()
 void SnakeGameEngine::tic(qreal elapsedTime)
 {
     mTotalElapsedTime += elapsedTime;
-    for (auto i = mEntities.begin(); i != mEntities.end(); ++i) {
-        Snake* snake{ dynamic_cast<Snake*>(*i) };
-        if (snake) {  
-            snake->ticExecute();
+    for (auto i = mEntities.begin(); i != mEntities.end();) {
+        if (!(*i)->isAlive()) {
+            delete* i;
+            i = mEntities.erase(i);
         }
-
+        else {
+            (*i)->ticPrepare(elapsedTime);
+            ++i;
+        }
+    /*Snake* snake{ dynamic_cast<Snake*>(*i) };
+        if (snake) {  
+            snake->ticPrepare(elapsedTime);
+        }*/
     }
 
 }
@@ -38,6 +45,7 @@ void SnakeGameEngine::clearAllEntity()
         // Pour acc?der aux donn?es de l'objet Entity, on doit d?r?f?rencer le pointeur
         // puis appeler la m?thode ou acc?der aux membres
         (*i)->setDead();
+        
     }
 
 }

--- a/GPA675_LAB2/SnakeGameEngine.cpp
+++ b/GPA675_LAB2/SnakeGameEngine.cpp
@@ -21,6 +21,7 @@ void SnakeGameEngine::tic(qreal elapsedTime)
     mTotalElapsedTime += elapsedTime;
     for (auto i = mEntities.begin(); i != mEntities.end(); ++i) {
 
+
         (*i)->ticPrepare(elapsedTime);
 
         Snake* snake{ dynamic_cast<Snake*>(*i) };

--- a/GPA675_LAB2/SnakeGameEngine.cpp
+++ b/GPA675_LAB2/SnakeGameEngine.cpp
@@ -18,19 +18,19 @@ SnakeGameEngine::~SnakeGameEngine()
 void SnakeGameEngine::tic(qreal elapsedTime)
 {
     mTotalElapsedTime += elapsedTime;
+    for (auto i = mEntities.begin(); i != mEntities.end(); ++i) {
+            (*i)->ticPrepare(elapsedTime);
+            
+    }
+
     for (auto i = mEntities.begin(); i != mEntities.end();) {
         if (!(*i)->isAlive()) {
             delete* i;
             i = mEntities.erase(i);
         }
         else {
-            (*i)->ticPrepare(elapsedTime);
             ++i;
         }
-    /*Snake* snake{ dynamic_cast<Snake*>(*i) };
-        if (snake) {  
-            snake->ticPrepare(elapsedTime);
-        }*/
     }
 
 }

--- a/GPA675_LAB2/StaticEntity.cpp
+++ b/GPA675_LAB2/StaticEntity.cpp
@@ -11,6 +11,7 @@ StaticEntity::StaticEntity(Board& board)
 
 StaticEntity::~StaticEntity()
 {
+    mBoard.setValue(mPosition.x(), mPosition.y(), nullptr);
 }
 
 bool StaticEntity::isValid()
@@ -25,6 +26,10 @@ bool StaticEntity::isAlive()
 
 void StaticEntity::ticPrepare(real elapsedTime)
 {
+    if (isColliding(mPosition)) {
+        mAlive = false;
+        return;
+    }
 
 }
 
@@ -36,14 +41,13 @@ void StaticEntity::ticExecute()
 void StaticEntity::draw(QPainter& painter)
 {
     painter.setPen(Qt::NoPen);
-    painter.setBrush(mColor);
-    painter.drawEllipse(QRectF(mPosition, QSize(mRadius, mRadius)));
+    painter.setPen(mColor);
+    painter.drawPoint(mPosition);
 }
 
 bool StaticEntity::isColliding(QPoint const& position)
 {
-
-    return mPosition == position;
+    return mBoard.value(position.x(),position.y()) != this;
 }
 
 QPoint StaticEntity::position() const
@@ -59,6 +63,7 @@ QColor StaticEntity::color() const
 void StaticEntity::setPosition(QPoint position)
 {
     mPosition = position;
+    mBoard.setValue(position.x(), position.y(), this);
 }
 
 void StaticEntity::setColor(QColor color)


### PR DESCRIPTION
Message de William:
Board:

Ajouté une fonction pour établir l'entité pointée à une position et une pour la remettre vide
Si une entité est déjà à la position qu'on essaie d'établir, on retourne l'entité déjà là, sinon nullptr(false)
Il va falloir utiliser la fonction 'setValue' à chaque fois qu'on touche une position (je crois l'avoir fait our l'instant, mais ça va être à vérifier et garder en tête)
Entity:

Ajouté une variable membre qui identifie avec quelle autre entité on partage une position
StaticEntity:
-Corrigé la façon de la dessiné

Établi sa présence sur le board quand on setPosition
Elle vérifie si une autre entité est à sa position, sinon se "tue"
Snake:

Ajusté la vitesse d'avance du serpent
Ajouté des fonctions utilitaires pour pas oublier de corriger la grid selon sa position
Ajouté une vérification de collision qui le fait grossir, mais va falloir revisiter la logique (il grossit plus tard)
**J'ai mis mes fonctions pour faire des tests dans GameApplication, mais il va falloir le bouger dans GameEngine en temps et lieu